### PR TITLE
Fix Windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ pbr = "1.0"
 prettytable-rs = "0.7"
 
 [target.'cfg(target_family = "windows")'.dependencies]
-dwrote = "0.5"
+dwrote = "0.5.1"
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
This fixes the issue with Windows not building because of a bad version of dwrote-rs (breaking changes in patch update).