### PR TITLE
implement glyph_by_name method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ features = ["minwindef", "winbase"]
 cocoa = "0.18"
 core-foundation = "0.6"
 core-graphics = "^0.17.1"
-core-text = "13.0"
+core-text = "13.2"
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos")))'.dependencies]
 freetype = "^0.4.1"

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -112,6 +112,12 @@ pub trait Loader: Clone + Sized {
     /// use cases like "what does character X look like on its own".
     fn glyph_for_char(&self, character: char) -> Option<u32>;
 
+    /// Returns the glyph ID for the specified glyph name.
+    #[inline]
+    fn glyph_by_name(&self, _name: &str) -> Option<u32> {
+        None
+    }
+
     /// Sends the vector path for a glyph to a path builder.
     ///
     /// If `hinting_mode` is not None, this function performs grid-fitting as requested before

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -289,6 +289,14 @@ impl Font {
         }
     }
 
+    /// Returns the glyph ID for the specified glyph name.
+    #[inline]
+    pub fn glyph_by_name(&self, name: &str) -> Option<u32> {
+        let code = self.core_text_font.get_glyph_with_name(name);
+
+        Some(u32::from(code))
+    }
+
     /// Sends the vector path for a glyph to a path builder.
     ///
     /// If `hinting_mode` is not None, this function performs grid-fitting as requested before
@@ -602,6 +610,11 @@ impl Loader for Font {
     #[inline]
     fn glyph_for_char(&self, character: char) -> Option<u32> {
         self.glyph_for_char(character)
+    }
+
+    #[inline]
+    fn glyph_by_name(&self, name: &str) -> Option<u32> {
+        self.glyph_by_name(name)
     }
 
     #[inline]

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -226,6 +226,12 @@ impl Font {
         self.dwrite_font_face.get_glyph_indices(&chars).into_iter().next().map(|g| g as u32)
     }
 
+    /// Returns the glyph ID for the specified glyph name.
+    #[inline]
+    pub fn glyph_by_name(&self, name: &str) -> Option<u32> {
+        None
+    }
+
     /// Returns the number of glyphs in the font.
     ///
     /// Glyph IDs range from 0 inclusive to this value exclusive.
@@ -560,6 +566,11 @@ impl Loader for Font {
     #[inline]
     fn glyph_for_char(&self, character: char) -> Option<u32> {
         self.glyph_for_char(character)
+    }
+
+    #[inline]
+    fn glyph_by_name(&self, name: &str) -> Option<u32> {
+        self.glyph_by_name(name)
     }
 
     #[inline]


### PR DESCRIPTION
This change implements looking up glyphs by their name, which is useful when dealing with fonts that may not have a cmap (in my case certain CFF files).

Implementing this outside fontkit, although possible, is quite cumbersome as I basically need to mirror all the platform-specific dependencies and compilation flags.

There's two rough edges at the moment that I'm happy to try and fix up if you're generally interested in this change. One being the FFI binding for `CTFontGetGlyphWithName` that should probably move into the `core-text` crate, and the other that there appears to be no simple way to do name-based lookup using the DirectWrite APIs.

Let me know what you think!