### PR TITLE
Add prototype fallback API for DirectWrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ pbr = "1.0"
 prettytable-rs = "0.7"
 
 [target.'cfg(target_family = "windows")'.dependencies]
-#dwrote = "0.8.0"
-dwrote = { path = "../dwrote-rs" }
+dwrote = "0.9.0"
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ pbr = "1.0"
 prettytable-rs = "0.7"
 
 [target.'cfg(target_family = "windows")'.dependencies]
-dwrote = "0.8.0"
+#dwrote = "0.8.0"
+dwrote = { path = "../dwrote-rs" }
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"

--- a/examples/fallback.rs
+++ b/examples/fallback.rs
@@ -1,0 +1,56 @@
+// font-kit/examples/fallback.rs
+//
+// Copyright © 2019 The Pathfinder Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate clap;
+extern crate font_kit;
+
+use clap::{App, Arg, ArgGroup, ArgMatches};
+
+use font_kit::source::SystemSource;
+
+#[cfg(any(target_family = "windows", target_os = "macos"))]
+static SANS_SERIF_FONT_REGULAR_POSTSCRIPT_NAME: &'static str = "ArialMT";
+#[cfg(not(any(target_family = "windows", target_os = "macos")))]
+static SANS_SERIF_FONT_REGULAR_POSTSCRIPT_NAME: &'static str = "DejaVuSans";
+
+fn get_args() -> ArgMatches<'static> {
+    let postscript_name_arg =
+        Arg::with_name("POSTSCRIPT-NAME").help("PostScript name of the font")
+                                         .default_value(SANS_SERIF_FONT_REGULAR_POSTSCRIPT_NAME)
+                                         .index(1);
+    let text_arg = Arg::with_name("TEXT").help("Text to query")
+                                         .default_value("A")
+                                         .index(2);
+    let locale_arg = Arg::with_name("LOCALE").help("Locale for fallback query")
+                                             .default_value("en-US")
+                                             .index(3);
+    App::new("fallback").version("0.1")
+                        .arg(postscript_name_arg)
+                        .arg(text_arg)
+                        .arg(locale_arg)
+                        .get_matches()
+}
+
+fn main() {
+    let matches = get_args();
+    let postscript_name = matches.value_of("POSTSCRIPT-NAME").unwrap();
+    let text = matches.value_of("TEXT").unwrap();
+    let locale = matches.value_of("LOCALE").unwrap();
+    let font = SystemSource::new().select_by_postscript_name(&postscript_name)
+                                  .expect("Font not found")
+                                  .load()
+                                  .unwrap();
+    println!("{}: text: {:?}", postscript_name, text);
+    let fallback_result = font.get_fallbacks(text, locale);
+    println!("fallback valid substring length: {}", fallback_result.valid_len);
+    for font in &fallback_result.fonts {
+        println!("font: {}", font.font.full_name());
+    }
+}

--- a/examples/fallback.rs
+++ b/examples/fallback.rs
@@ -11,8 +11,9 @@
 extern crate clap;
 extern crate font_kit;
 
-use clap::{App, Arg, ArgGroup, ArgMatches};
+use clap::{App, Arg, ArgMatches};
 
+use font_kit::loader::Loader;
 use font_kit::source::SystemSource;
 
 #[cfg(any(target_family = "windows", target_os = "macos"))]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -190,4 +190,27 @@ pub trait Loader: Clone + Sized {
                        hinting_options: HintingOptions,
                        rasterization_options: RasterizationOptions)
                        -> Result<(), GlyphLoadingError>;
+
+    /// Get font fallback results for the given text and locale.
+    ///
+    /// The `locale` argument is a language tag such as `"en-US"` or `"zh-Hans-CN"`.
+    fn get_fallbacks(&self, text: &str, locale: &str) -> FallbackResult<Self>;
+}
+
+/// The result of a fallback query.
+pub struct FallbackResult<Font> {
+    /// A list of fallback fonts.
+    pub fonts: Vec<FallbackFont<Font>>,
+    /// The fallback list is valid for this slice of the given text.
+    pub valid_len: usize,
+}
+
+/// A single font record for a fallback query result.
+pub struct FallbackFont<Font> {
+    /// The font.
+    pub font: Font,
+    /// A scale factor that should be applied to the fallback font.
+    pub scale: f32,
+
+    // TODO: add font simulation data
 }

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -39,7 +39,7 @@ use error::{FontLoadingError, GlyphLoadingError};
 use file_type::FileType;
 use handle::Handle;
 use hinting::HintingOptions;
-use loader::Loader;
+use loader::{FallbackResult, Loader};
 use metrics::Metrics;
 use properties::{Properties, Stretch, Style, Weight};
 use sources;
@@ -535,6 +535,17 @@ impl Font {
         }
     }
 
+    /// Get font fallback results for the given text and locale.
+    ///
+    /// Note: this is currently just a stub implementation, a proper implementation
+    /// would use CTFontCopyDefaultCascadeListForLanguages.
+    fn get_fallbacks(&self, text: &str, _locale: &str) -> FallbackResult<Font> {
+        FallbackResult {
+            fonts: Vec::new(),
+            valid_len: text.len(),
+        }
+    }
+
     #[inline]
     fn units_per_point(&self) -> f64 {
         (self.core_text_font.units_per_em() as f64) / self.core_text_font.pt_size()
@@ -662,6 +673,11 @@ impl Loader for Font {
                              origin,
                              hinting_options,
                              rasterization_options)
+    }
+
+    #[inline]
+    fn get_fallbacks(&self, text: &str, locale: &str) -> FallbackResult<Self> {
+        self.get_fallbacks(text, locale)
     }
 }
 

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -88,11 +88,12 @@ pub struct FallbackFont {
 
 struct MyTextAnalysisSource {
     text_utf16_len: u32,
+    locale: String,
 }
 
 impl dwrote::TextAnalysisSourceMethods for MyTextAnalysisSource {
     fn get_locale_name<'a>(&'a self, text_pos: u32) -> (Cow<'a, str>, u32) {
-        ("en-US".into(), self.text_utf16_len - text_pos)
+        (self.locale.as_str().into(), self.text_utf16_len - text_pos)
     }
 
     fn get_paragraph_reading_direction(&self) -> DWRITE_READING_DIRECTION {
@@ -519,7 +520,9 @@ impl Font {
     }
 
     /// Get font fallback results for the given text and locale.
-    /// 
+    ///
+    /// The `locale` argument is a language tag such as `"en-US"` or `"zh-Hans-CN"`.
+    ///
     /// Note: on Windows 10, the result is a single font.
     pub fn get_fallbacks(&self, text: &str, locale: &str) -> FallbackResult {
         let sys_fallback = DWriteFontFallback::get_system_fallback();
@@ -535,6 +538,7 @@ impl Font {
         );
         let text_analysis_source = MyTextAnalysisSource {
             text_utf16_len,
+            locale: locale.to_owned(),
         };
         let text_analysis = dwrote::TextAnalysisSource::from_text_and_number_subst(
             Box::new(text_analysis_source),

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -806,7 +806,8 @@ impl Font {
     /// Get font fallback results for the given text and locale.
     ///
     /// Note: this is currently just a stub implementation, a proper implementation
-    /// would use CTFontCopyDefaultCascadeListForLanguages.
+    /// would likely use FontConfig, at least on Linux. It's not clear what a
+    /// FreeType loader with a non-FreeType source should do.
     fn get_fallbacks(&self, text: &str, _locale: &str) -> FallbackResult<Font> {
         FallbackResult {
             fonts: Vec::new(),

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -43,7 +43,7 @@ use error::{FontLoadingError, GlyphLoadingError};
 use file_type::FileType;
 use handle::Handle;
 use hinting::HintingOptions;
-use loader::Loader;
+use loader::{FallbackResult, Loader};
 use metrics::Metrics;
 use properties::{Properties, Stretch, Style, Weight};
 
@@ -802,6 +802,17 @@ impl Font {
             FontData::Memory(ref memory) => Some((*memory).clone()),
         }
     }
+
+    /// Get font fallback results for the given text and locale.
+    ///
+    /// Note: this is currently just a stub implementation, a proper implementation
+    /// would use CTFontCopyDefaultCascadeListForLanguages.
+    fn get_fallbacks(&self, text: &str, _locale: &str) -> FallbackResult<Font> {
+        FallbackResult {
+            fonts: Vec::new(),
+            valid_len: text.len(),
+        }
+    }
 }
 
 impl Clone for Font {
@@ -952,6 +963,11 @@ impl Loader for Font {
                              origin,
                              hinting_options,
                              rasterization_options)
+    }
+
+    #[inline]
+    fn get_fallbacks(&self, text: &str, locale: &str) -> FallbackResult<Self> {
+        self.get_fallbacks(text, locale)
     }
 }
 


### PR DESCRIPTION
Note: this version will fail to compile unless the dwrote dep is manually patched to git master, as a release hasn't been done with https://github.com/servo/dwrote-rs/pull/32

An additional concern is performance, as the font data will need to be copied each time a fallback font is used.

Addresses #37 
