### PR TITLE
Use a simpler table format.

### DIFF
--- a/examples/list-fonts.rs
+++ b/examples/list-fonts.rs
@@ -22,7 +22,8 @@ use prettytable::row::Row;
 
 fn main() {
     let mut table = Table::new();
-    table.add_row(Row::new(vec![
+    table.set_format(*prettytable::format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+    table.set_titles(Row::new(vec![
         Cell::new("PostScript Name").with_style(Attr::Bold),
         Cell::new("Name").with_style(Attr::Bold),
         Cell::new("Family").with_style(Attr::Bold),


### PR DESCRIPTION
Before:

```
+---------------------------------------+----------------------------------+----------------------------------+--------+--------+---------+
| PostScript Name                       | Name                             | Family                           | Style  | Weight | Stretch |
+---------------------------------------+----------------------------------+----------------------------------+--------+--------+---------+
| AndaleMono                            | Andale Mono                      | Andale Mono                      | Normal | 400    | 1       |
+---------------------------------------+----------------------------------+----------------------------------+--------+--------+---------+
| CourierNewPSMT                        | Courier New                      | Andale Mono                      | Normal | 400    | 1       |
+---------------------------------------+----------------------------------+----------------------------------+--------+--------+---------+
| CourierNewPS-ItalicMT                 | Courier New Italic               | Andale Mono                      | Italic | 400    | 1       |
+---------------------------------------+----------------------------------+----------------------------------+--------+--------+---------+
```

After:
```
 PostScript Name                       | Name                             | Family                           | Style  | Weight | Stretch 
---------------------------------------+----------------------------------+----------------------------------+--------+--------+---------
 AndaleMono                            | Andale Mono                      | Andale Mono                      | Normal | 400    | 1 
 CourierNewPSMT                        | Courier New                      | Andale Mono                      | Normal | 400    | 1 
 CourierNewPS-ItalicMT                 | Courier New Italic               | Andale Mono                      | Italic | 400    | 1
```