### PR TITLE
Check results in Loader::glyph_for_char.

### DIFF
--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -284,17 +284,13 @@ impl Font {
         unsafe {
             let (mut dest, mut src) = ([0, 0], [0, 0]);
             let src = character.encode_utf16(&mut src);
-            let ok = self.core_text_font.get_glyphs_for_characters(
+            self.core_text_font.get_glyphs_for_characters(
                 src.as_ptr(), dest.as_mut_ptr(), 2
             );
 
-            dbg!(character);
-            dbg!(ok);
-            dbg!(src);
-            dbg!(dest);
-
-            if ok {
-                Some(dest[0] as u32)
+            let id = dest[0] as u32;
+            if id != 0 {
+                Some(id)
             } else {
                 None
             }

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -288,6 +288,11 @@ impl Font {
                 src.as_ptr(), dest.as_mut_ptr(), 2
             );
 
+            dbg!(character);
+            dbg!(ok);
+            dbg!(src);
+            dbg!(dest);
+
             if ok {
                 Some(dest[0] as u32)
             } else {

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -284,8 +284,15 @@ impl Font {
         unsafe {
             let (mut dest, mut src) = ([0, 0], [0, 0]);
             let src = character.encode_utf16(&mut src);
-            self.core_text_font.get_glyphs_for_characters(src.as_ptr(), dest.as_mut_ptr(), 2);
-            Some(dest[0] as u32)
+            let ok = self.core_text_font.get_glyphs_for_characters(
+                src.as_ptr(), dest.as_mut_ptr(), 2
+            );
+
+            if ok {
+                Some(dest[0] as u32)
+            } else {
+                None
+            }
         }
     }
 

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -365,7 +365,11 @@ impl Font {
     #[inline]
     pub fn glyph_for_char(&self, character: char) -> Option<u32> {
         unsafe {
-            Some(FT_Get_Char_Index(self.freetype_face, character as FT_ULong))
+            let res = FT_Get_Char_Index(self.freetype_face, character as FT_ULong);
+            match res {
+                0 => None,
+                _ => Some(res),
+            }
         }
     }
 


### PR DESCRIPTION
Previously, `glyph_for_char` in CoreText and FreeType loaders were always
returned `Some`, instead of checking results.

Closes #38