### PR TITLE
Use Impact as a default fantasy font on Windows.

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -38,7 +38,9 @@ const DEFAULT_FONT_FAMILY_SANS_SERIF: &'static str = "Arial";
 const DEFAULT_FONT_FAMILY_MONOSPACE: &'static str = "Courier New";
 #[cfg(any(target_family = "windows", target_os = "macos"))]
 const DEFAULT_FONT_FAMILY_CURSIVE: &'static str = "Comic Sans MS";
-#[cfg(any(target_family = "windows", target_os = "macos"))]
+#[cfg(target_family = "windows")]
+const DEFAULT_FONT_FAMILY_FANTASY: &'static str = "Impact";
+#[cfg(target_os = "macos")]
 const DEFAULT_FONT_FAMILY_FANTASY: &'static str = "Papyrus";
 
 #[cfg(not(any(target_family = "windows", target_os = "macos")))]


### PR DESCRIPTION
According to https://www.w3.org/Style/Examples/007/fonts.en.html

Closes #58