### PR TITLE
Support blits with an offset

### DIFF
--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -23,6 +23,7 @@ use dwrote::InformationalStringId as DWriteInformationalStringId;
 use dwrote::{DWRITE_TEXTURE_ALIASED_1x1, DWRITE_RENDERING_MODE_NATURAL};
 use dwrote::{DWRITE_TEXTURE_CLEARTYPE_3x1, OutlineBuilder};
 use dwrote::{DWRITE_GLYPH_RUN, DWRITE_MEASURING_MODE_NATURAL, DWRITE_RENDERING_MODE_ALIASED};
+use euclid::point2;
 use euclid::{Point2D, Rect, Size2D, Vector2D};
 use lyon_path::builder::PathBuilder;
 use lyon_path::PathEvent;
@@ -466,6 +467,7 @@ impl Font {
         let mut texture_bytes =
             dwrite_analysis.create_alpha_texture(texture_type, texture_bounds)?;
         canvas.blit_from(
+            point2(0, 0),
             &mut texture_bytes,
             &texture_size,
             texture_stride,
@@ -500,7 +502,7 @@ impl Font {
         &self,
         glyph_id: u32,
         point_size: f32,
-        _origin: &Point2D<f32>,
+        origin: &Point2D<f32>,
         _hinting_options: HintingOptions,
         rasterization_options: RasterizationOptions,
     ) -> Result<DWriteGlyphRunAnalysis, GlyphLoadingError> {
@@ -532,7 +534,14 @@ impl Font {
             Ok(DWriteGlyphRunAnalysis::create(
                 &glyph_run,
                 1.0,
-                None,
+                Some(dwrote::DWRITE_MATRIX {
+                    m11: 1.,
+                    m12: 0.,
+                    m21: 0.,
+                    m22: 1.,
+                    dx: origin.x,
+                    dy: origin.y,
+                }),
                 rendering_mode,
                 DWRITE_MEASURING_MODE_NATURAL,
                 0.0,

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -15,7 +15,7 @@
 
 use byteorder::{BigEndian, ReadBytesExt};
 use canvas::{Canvas, Format, RasterizationOptions};
-use euclid::{Point2D, Rect, Size2D, Vector2D};
+use euclid::{point2, Point2D, Rect, Size2D, Vector2D};
 use freetype::freetype::{FT_Byte, FT_Done_Face, FT_Error, FT_Face, FT_FACE_FLAG_FIXED_WIDTH};
 use freetype::freetype::{
     FT_Get_Char_Index, FT_Get_Name_Index, FT_Get_Postscript_Name, FT_Get_Sfnt_Table,
@@ -838,17 +838,24 @@ impl Font {
             let bitmap_buffer = (*bitmap).buffer as *const i8 as *const u8;
             let bitmap_length = bitmap_stride * bitmap_height as usize;
             let buffer = slice::from_raw_parts(bitmap_buffer, bitmap_length);
+            let dst_point = point2(0, 0);
 
             // FIXME(pcwalton): This function should return a Result instead.
             match (*bitmap).pixel_mode {
                 FT_PIXEL_MODE_GRAY => {
-                    canvas.blit_from(buffer, &bitmap_size, bitmap_stride, Format::A8);
+                    canvas.blit_from(dst_point, buffer, &bitmap_size, bitmap_stride, Format::A8);
                 }
                 FT_PIXEL_MODE_LCD | FT_PIXEL_MODE_LCD_V => {
-                    canvas.blit_from(buffer, &bitmap_size, bitmap_stride, Format::Rgb24);
+                    canvas.blit_from(
+                        dst_point,
+                        buffer,
+                        &bitmap_size,
+                        bitmap_stride,
+                        Format::Rgb24,
+                    );
                 }
                 FT_PIXEL_MODE_MONO => {
-                    canvas.blit_from_bitmap_1bpp(buffer, &bitmap_size, bitmap_stride);
+                    canvas.blit_from_bitmap_1bpp(dst_point, buffer, &bitmap_size, bitmap_stride);
                 }
                 _ => panic!("Unexpected FreeType pixel mode!"),
             }


### PR DESCRIPTION
This will be used to implement proper origin support in the freetype and
directwrite loaders. Currently those loaders either ignore the origin
or only use the fractional part.