### PR TITLE
Upgrade to 2018 edition and reduce unnecessary dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,9 @@ freetype = "^0.4.1"
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_arch = "wasm32")))'.dependencies]
 servo-fontconfig = "0.4"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android")))'.dependencies]
 dirs = "1.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = "0.7"
 walkdir = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/pcwalton/font-kit"
 homepage = "https://github.com/pcwalton/font-kit"
 exclude = ["resources/**"]
+edition = "2018"
 
 [features]
 loader-freetype = ["freetype"]

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -11,6 +11,7 @@
 //! An in-memory bitmap surface for glyph rasterization.
 
 use euclid::{point2, rect, Point2D, Rect, Size2D};
+use lazy_static::lazy_static;
 use std::cmp;
 use std::fmt;
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -14,7 +14,7 @@ use euclid::{point2, rect, Point2D, Rect, Size2D};
 use std::cmp;
 use std::fmt;
 
-use utils;
+use crate::utils;
 
 lazy_static! {
     static ref BITMAP_1BPP_TO_8BPP_LUT: [[u8; 8]; 256] = {

--- a/src/family.rs
+++ b/src/family.rs
@@ -10,11 +10,11 @@
 
 //! Defines a set of faces that vary in weight, width or slope.
 
-use error::FontLoadingError;
-use family_handle::FamilyHandle;
-use font::Font;
-use handle::Handle;
-use loader::Loader;
+use crate::error::FontLoadingError;
+use crate::family_handle::FamilyHandle;
+use crate::font::Font;
+use crate::handle::Handle;
+use crate::loader::Loader;
 
 /// Defines a set of faces that vary in weight, width or slope.
 #[derive(Debug)]

--- a/src/family_handle.rs
+++ b/src/family_handle.rs
@@ -10,7 +10,7 @@
 
 //! Encapsulates the information needed to locate and open the fonts in a family.
 
-use handle::Handle;
+use crate::handle::Handle;
 
 /// Encapsulates the information needed to locate and open the fonts in a family.
 #[derive(Debug)]

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,4 +12,4 @@
 //!
 //! The Font type in this crate represents the default loader.
 
-pub use loaders::default::Font;
+pub use crate::loaders::default::Font;

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -17,8 +17,8 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use error::FontLoadingError;
-use font::Font;
+use crate::error::FontLoadingError;
+use crate::font::Font;
 
 /// Encapsulates the information needed to locate and open a font.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,47 +120,6 @@
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]
 
-extern crate byteorder;
-extern crate euclid;
-extern crate float_ord;
-extern crate libc;
-extern crate lyon_path;
-
-#[allow(unused_imports)]
-#[macro_use]
-extern crate lazy_static;
-#[allow(unused_imports)]
-#[macro_use]
-extern crate log;
-
-#[cfg(target_os = "macos")]
-extern crate core_foundation;
-#[cfg(target_os = "macos")]
-extern crate core_graphics;
-#[cfg(target_os = "macos")]
-extern crate core_text;
-#[cfg(not(target_arch = "wasm32"))]
-#[allow(unused_imports)]
-extern crate dirs;
-#[cfg(target_family = "windows")]
-extern crate dwrote;
-#[cfg(any(
-    not(any(target_os = "macos", target_family = "windows", target_arch = "wasm32")),
-    feature = "source-fontconfig"
-))]
-extern crate fontconfig;
-#[cfg(any(
-    not(any(target_os = "macos", target_family = "windows")),
-    feature = "loader-freetype"
-))]
-extern crate freetype;
-#[cfg(not(target_arch = "wasm32"))]
-extern crate memmap;
-#[cfg(not(target_arch = "wasm32"))]
-extern crate walkdir;
-#[cfg(target_family = "windows")]
-extern crate winapi;
-
 pub mod canvas;
 pub mod error;
 pub mod family;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -15,13 +15,13 @@ use euclid::{Point2D, Rect, Vector2D};
 use lyon_path::builder::PathBuilder;
 use std::sync::Arc;
 
-use canvas::{Canvas, RasterizationOptions};
-use error::{FontLoadingError, GlyphLoadingError};
-use file_type::FileType;
-use handle::Handle;
-use hinting::HintingOptions;
-use metrics::Metrics;
-use properties::Properties;
+use crate::canvas::{Canvas, RasterizationOptions};
+use crate::error::{FontLoadingError, GlyphLoadingError};
+use crate::file_type::FileType;
+use crate::handle::Handle;
+use crate::hinting::HintingOptions;
+use crate::metrics::Metrics;
+use crate::properties::Properties;
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::fs::File;
@@ -56,7 +56,7 @@ pub trait Loader: Clone + Sized {
     where
         P: AsRef<Path>,
     {
-        Loader::from_file(&mut try!(File::open(path)), font_index)
+        Loader::from_file(&mut File::open(path)?, font_index)
     }
 
     /// Creates a font from a native API handle.
@@ -94,7 +94,7 @@ pub trait Loader: Clone + Sized {
     where
         P: AsRef<Path>,
     {
-        <Self as Loader>::analyze_file(&mut try!(File::open(path)))
+        <Self as Loader>::analyze_file(&mut File::open(path)?)
     }
 
     /// Returns the wrapped native font handle.

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -12,6 +12,7 @@
 //! fonts.
 
 use euclid::{Point2D, Rect, Vector2D};
+use log::warn;
 use lyon_path::builder::PathBuilder;
 use std::sync::Arc;
 

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -34,16 +34,16 @@ use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 
-use canvas::{Canvas, Format, RasterizationOptions};
-use error::{FontLoadingError, GlyphLoadingError};
-use file_type::FileType;
-use handle::Handle;
-use hinting::HintingOptions;
-use loader::{FallbackResult, Loader};
-use metrics::Metrics;
-use properties::{Properties, Stretch, Style, Weight};
-use sources;
-use utils;
+use crate::canvas::{Canvas, Format, RasterizationOptions};
+use crate::error::{FontLoadingError, GlyphLoadingError};
+use crate::file_type::FileType;
+use crate::handle::Handle;
+use crate::hinting::HintingOptions;
+use crate::loader::{FallbackResult, Loader};
+use crate::metrics::Metrics;
+use crate::properties::{Properties, Stretch, Style, Weight};
+use crate::sources;
+use crate::utils;
 
 const TTC_TAG: [u8; 4] = [b't', b't', b'c', b'f'];
 

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -24,6 +24,7 @@ use core_text::font::CTFont;
 use core_text::font_descriptor::kCTFontDefaultOrientation;
 use core_text::font_descriptor::{SymbolicTraitAccessors, TraitAccessors};
 use euclid::{Point2D, Rect, Size2D, Vector2D};
+use log::warn;
 use lyon_path::builder::PathBuilder;
 use memmap::{Mmap, MmapOptions};
 use std::f32;
@@ -870,8 +871,8 @@ fn format_to_cg_color_space_and_image_format(format: Format) -> Option<(CGColorS
 #[cfg(test)]
 mod test {
     use super::Font;
-    use properties::{Stretch, Weight};
-    use source::SystemSource;
+    use crate::properties::{Stretch, Weight};
+    use crate::source::SystemSource;
 
     static TEST_FONT_POSTSCRIPT_NAME: &'static str = "ArialMT";
 

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -43,14 +43,14 @@ use winapi::um::dwrite::{
 };
 use winapi::um::fileapi;
 
-use canvas::{Canvas, Format, RasterizationOptions};
-use error::{FontLoadingError, GlyphLoadingError};
-use file_type::FileType;
-use handle::Handle;
-use hinting::HintingOptions;
-use loader::{FallbackFont, FallbackResult, Loader};
-use metrics::Metrics;
-use properties::{Properties, Stretch, Style, Weight};
+use crate::canvas::{Canvas, Format, RasterizationOptions};
+use crate::error::{FontLoadingError, GlyphLoadingError};
+use crate::file_type::FileType;
+use crate::handle::Handle;
+use crate::hinting::HintingOptions;
+use crate::loader::{FallbackFont, FallbackResult, Loader};
+use crate::metrics::Metrics;
+use crate::properties::{Properties, Stretch, Style, Weight};
 
 const ERROR_BOUND: f32 = 0.0001;
 

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -38,13 +38,13 @@ use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
-use error::{FontLoadingError, GlyphLoadingError};
-use file_type::FileType;
-use handle::Handle;
-use hinting::HintingOptions;
-use loader::{FallbackResult, Loader};
-use metrics::Metrics;
-use properties::{Properties, Stretch, Style, Weight};
+use crate::error::{FontLoadingError, GlyphLoadingError};
+use crate::file_type::FileType;
+use crate::handle::Handle;
+use crate::hinting::HintingOptions;
+use crate::loader::{FallbackResult, Loader};
+use crate::metrics::Metrics;
+use crate::properties::{Properties, Stretch, Style, Weight};
 
 #[cfg(not(target_arch = "wasm32"))]
 use memmap::Mmap;

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -14,7 +14,6 @@
 //! loader by default.
 
 use byteorder::{BigEndian, ReadBytesExt};
-use canvas::{Canvas, Format, RasterizationOptions};
 use euclid::{point2, Point2D, Rect, Size2D, Vector2D};
 use freetype::freetype::{FT_Byte, FT_Done_Face, FT_Error, FT_Face, FT_FACE_FLAG_FIXED_WIDTH};
 use freetype::freetype::{
@@ -26,6 +25,7 @@ use freetype::freetype::{FT_New_Memory_Face, FT_Reference_Face, FT_STYLE_FLAG_IT
 use freetype::freetype::{FT_Set_Char_Size, FT_Set_Transform, FT_Sfnt_Tag, FT_UInt, FT_ULong};
 use freetype::freetype::{FT_UShort, FT_Vector};
 use freetype::tt_os2::TT_OS2;
+use log::warn;
 use lyon_path::builder::PathBuilder;
 use std::f32;
 use std::ffi::{CStr, CString};
@@ -38,6 +38,7 @@ use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
+use crate::canvas::{Canvas, Format, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -1167,7 +1168,7 @@ extern "C" {
 
 #[cfg(test)]
 mod test {
-    use loaders::freetype::Font;
+    use crate::loaders::freetype::Font;
 
     static PCF_FONT_PATH: &'static str = "resources/tests/times-roman-pcf/timR12.pcf";
     static PCF_FONT_POSTSCRIPT_NAME: &'static str = "Times-Roman";

--- a/src/loaders/mod.rs
+++ b/src/loaders/mod.rs
@@ -11,16 +11,16 @@
 //! The different system services that can load and rasterize fonts.
 
 #[cfg(all(target_os = "macos", not(feature = "loader-freetype-default")))]
-pub use loaders::core_text as default;
+pub use crate::loaders::core_text as default;
 
 #[cfg(all(target_family = "windows", not(feature = "loader-freetype-default")))]
-pub use loaders::directwrite as default;
+pub use crate::loaders::directwrite as default;
 
 #[cfg(any(
     not(any(target_os = "macos", target_family = "windows")),
     feature = "loader-freetype-default"
 ))]
-pub use loaders::freetype as default;
+pub use crate::loaders::freetype as default;
 
 #[cfg(all(target_os = "macos"))]
 pub mod core_text;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -12,8 +12,8 @@
 
 use float_ord::FloatOrd;
 
-use error::SelectionError;
-use properties::{Properties, Stretch, Style, Weight};
+use crate::error::SelectionError;
+use crate::properties::{Properties, Stretch, Style, Weight};
 
 #[derive(Debug)]
 pub struct Description {

--- a/src/source.rs
+++ b/src/source.rs
@@ -10,19 +10,19 @@
 
 //! A database of installed fonts that can be queried.
 
-use error::SelectionError;
-use family::Family;
-use family_handle::FamilyHandle;
-use family_name::FamilyName;
-use font::Font;
-use handle::Handle;
-use matching::{self, Description};
-use properties::Properties;
+use crate::error::SelectionError;
+use crate::family::Family;
+use crate::family_handle::FamilyHandle;
+use crate::family_name::FamilyName;
+use crate::font::Font;
+use crate::handle::Handle;
+use crate::matching::{self, Description};
+use crate::properties::Properties;
 
 #[cfg(all(target_os = "macos", not(feature = "source-fontconfig-default")))]
-pub use sources::core_text::CoreTextSource as SystemSource;
+pub use crate::sources::core_text::CoreTextSource as SystemSource;
 #[cfg(all(target_family = "windows", not(feature = "source-fontconfig-default")))]
-pub use sources::directwrite::DirectWriteSource as SystemSource;
+pub use crate::sources::directwrite::DirectWriteSource as SystemSource;
 #[cfg(any(
     not(any(
         target_os = "android",
@@ -32,9 +32,9 @@ pub use sources::directwrite::DirectWriteSource as SystemSource;
     )),
     feature = "source-fontconfig-default"
 ))]
-pub use sources::fontconfig::FontconfigSource as SystemSource;
+pub use crate::sources::fontconfig::FontconfigSource as SystemSource;
 #[cfg(all(target_os = "android", not(feature = "source-fontconfig-default")))]
-pub use sources::fs::FsSource as SystemSource;
+pub use crate::sources::fs::FsSource as SystemSource;
 
 // FIXME(pcwalton): These could expand to multiple fonts, and they could be language-specific.
 #[cfg(any(target_family = "windows", target_os = "macos"))]

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -21,15 +21,15 @@ use std::cmp::Ordering;
 use std::f32;
 use std::path::Path;
 
-use error::SelectionError;
-use family_handle::FamilyHandle;
-use family_name::FamilyName;
-use file_type::FileType;
-use font::Font;
-use handle::Handle;
-use properties::{Properties, Stretch, Weight};
-use source::Source;
-use utils;
+use crate::error::SelectionError;
+use crate::family_handle::FamilyHandle;
+use crate::family_name::FamilyName;
+use crate::file_type::FileType;
+use crate::font::Font;
+use crate::handle::Handle;
+use crate::properties::{Properties, Stretch, Weight};
+use crate::source::Source;
+use crate::utils;
 
 pub(crate) static FONT_WEIGHT_MAPPING: [f32; 9] = [-0.7, -0.5, -0.23, 0.0, 0.2, 0.3, 0.4, 0.6, 0.8];
 

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -199,7 +199,7 @@ fn create_handle_from_descriptor(descriptor: &CTFontDescriptor) -> Handle {
 
 #[cfg(test)]
 mod test {
-    use properties::{Stretch, Weight};
+    use crate::properties::{Stretch, Weight};
 
     #[test]
     fn test_css_to_core_text_font_weight() {

--- a/src/sources/directwrite.rs
+++ b/src/sources/directwrite.rs
@@ -13,12 +13,12 @@
 use dwrote::Font as DWriteFont;
 use dwrote::FontCollection as DWriteFontCollection;
 
-use error::SelectionError;
-use family_handle::FamilyHandle;
-use family_name::FamilyName;
-use handle::Handle;
-use properties::Properties;
-use source::Source;
+use crate::error::SelectionError;
+use crate::family_handle::FamilyHandle;
+use crate::family_name::FamilyName;
+use crate::handle::Handle;
+use crate::properties::Properties;
+use crate::source::Source;
 
 /// A source that contains the installed fonts on Windows.
 #[allow(missing_debug_implementations)]

--- a/src/sources/fontconfig.rs
+++ b/src/sources/fontconfig.rs
@@ -15,12 +15,12 @@
 //! support. To prefer it over the native font source (only if you know what you're doing), use the
 //! `source-fontconfig-default` feature.
 
-use error::SelectionError;
-use family_handle::FamilyHandle;
-use family_name::FamilyName;
-use handle::Handle;
-use properties::Properties;
-use source::Source;
+use crate::error::SelectionError;
+use crate::family_handle::FamilyHandle;
+use crate::family_name::FamilyName;
+use crate::handle::Handle;
+use crate::properties::Properties;
+use crate::source::Source;
 
 /// A source that contains the fonts installed on the system, as reported by the Fontconfig
 /// library.

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -29,15 +29,15 @@ use winapi::shared::minwindef::{MAX_PATH, UINT};
 #[cfg(target_family = "windows")]
 use winapi::um::sysinfoapi;
 
-use error::SelectionError;
-use family_handle::FamilyHandle;
-use family_name::FamilyName;
-use file_type::FileType;
-use font::Font;
-use handle::Handle;
-use properties::Properties;
-use source::Source;
-use sources::mem::MemSource;
+use crate::error::SelectionError;
+use crate::family_handle::FamilyHandle;
+use crate::family_name::FamilyName;
+use crate::file_type::FileType;
+use crate::font::Font;
+use crate::handle::Handle;
+use crate::properties::Properties;
+use crate::source::Source;
+use crate::sources::mem::MemSource;
 
 /// A source that loads fonts from a directory or directories on disk.
 ///

--- a/src/sources/mem.rs
+++ b/src/sources/mem.rs
@@ -10,13 +10,13 @@
 
 //! A source that keeps fonts in memory.
 
-use error::{FontLoadingError, SelectionError};
-use family_handle::FamilyHandle;
-use family_name::FamilyName;
-use font::Font;
-use handle::Handle;
-use properties::Properties;
-use source::Source;
+use crate::error::{FontLoadingError, SelectionError};
+use crate::family_handle::FamilyHandle;
+use crate::family_name::FamilyName;
+use crate::font::Font;
+use crate::handle::Handle;
+use crate::properties::Properties;
+use crate::source::Source;
 
 /// A source that keeps fonts in memory.
 #[allow(missing_debug_implementations)]

--- a/src/sources/multi.rs
+++ b/src/sources/multi.rs
@@ -13,12 +13,12 @@
 //! This is useful when an application wants a library of fonts consisting of the installed system
 //! fonts plus some other application-supplied fonts.
 
-use error::SelectionError;
-use family_handle::FamilyHandle;
-use family_name::FamilyName;
-use handle::Handle;
-use properties::Properties;
-use source::Source;
+use crate::error::SelectionError;
+use crate::family_handle::FamilyHandle;
+use crate::family_name::FamilyName;
+use crate::handle::Handle;
+use crate::properties::Properties;
+use crate::source::Source;
 
 /// A source that encapsulates multiple sources and allows them to be queried as a group.
 ///

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,14 +16,14 @@ use std::fs::File;
 use std::io::Read;
 use std::sync::Arc;
 
-use canvas::{Canvas, Format, RasterizationOptions};
-use family_name::FamilyName;
-use file_type::FileType;
-use font::Font;
-use hinting::HintingOptions;
-use properties::{Properties, Stretch, Weight};
-use source::SystemSource;
-use utils;
+use crate::canvas::{Canvas, Format, RasterizationOptions};
+use crate::family_name::FamilyName;
+use crate::file_type::FileType;
+use crate::font::Font;
+use crate::hinting::HintingOptions;
+use crate::properties::{Properties, Stretch, Weight};
+use crate::source::SystemSource;
+use crate::utils;
 
 static TEST_FONT_FILE_PATH: &'static str = "resources/tests/eb-garamond/EBGaramond12-Regular.otf";
 static TEST_FONT_POSTSCRIPT_NAME: &'static str = "EBGaramond12-Regular";


### PR DESCRIPTION
This avoids building the `dirs` crate on Windows where it is unused.