### PR TITLE
 Properly support the offset in dwrite and freetype loaders.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT/Apache-2.0"

--- a/examples/render-glyph.rs
+++ b/examples/render-glyph.rs
@@ -116,7 +116,11 @@ fn main() {
 
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), canvas_format);
 
-    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
+    let origin = Point2D::new(
+        -raster_rect.origin.x,
+        raster_rect.size.height + raster_rect.origin.y,
+    )
+    .to_f32();
     font.rasterize_glyph(
         &mut canvas,
         glyph_id,

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -467,7 +467,7 @@ impl Font {
         let mut texture_bytes =
             dwrite_analysis.create_alpha_texture(texture_type, texture_bounds)?;
         canvas.blit_from(
-            point2(0, 0),
+            point2(texture_bounds.left, texture_bounds.top),
             &mut texture_bytes,
             &texture_size,
             texture_stride,

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -803,7 +803,7 @@ impl Font {
         unsafe {
             let mut delta = FT_Vector {
                 x: f32_to_ft_fixed_26_6(origin.x),
-                y: f32_to_ft_fixed_26_6(origin.y),
+                y: f32_to_ft_fixed_26_6(-origin.y),
             };
             FT_Set_Transform(self.freetype_face, ptr::null_mut(), &mut delta);
 
@@ -838,7 +838,10 @@ impl Font {
             let bitmap_buffer = (*bitmap).buffer as *const i8 as *const u8;
             let bitmap_length = bitmap_stride * bitmap_height as usize;
             let buffer = slice::from_raw_parts(bitmap_buffer, bitmap_length);
-            let dst_point = point2(0, 0);
+            let dst_point = point2(
+                (*(*self.freetype_face).glyph).bitmap_left,
+                -(*(*self.freetype_face).glyph).bitmap_top,
+            );
 
             // FIXME(pcwalton): This function should return a Result instead.
             match (*bitmap).pixel_mode {

--- a/src/test.rs
+++ b/src/test.rs
@@ -976,17 +976,17 @@ fn check_L_shape(canvas: &Canvas) {
     let mut y = 0;
     while y < canvas.size.height {
         let (row_start, row_end) = (canvas.stride * y as usize, canvas.stride * (y + 1) as usize);
-        y += 1;
         if canvas.pixels[row_start..row_end].iter().any(|&p| p != 0) {
             break;
         }
+        y += 1;
     }
+    assert!(y < canvas.size.height);
 
     // Find the top part of the L.
     let mut top_stripe_width = None;
     while y < canvas.size.height {
         let (row_start, row_end) = (canvas.stride * y as usize, canvas.stride * (y + 1) as usize);
-        y += 1;
         if let Some(stripe_width) = stripe_width(&canvas.pixels[row_start..row_end]) {
             if let Some(top_stripe_width) = top_stripe_width {
                 if stripe_width > top_stripe_width {
@@ -996,7 +996,9 @@ fn check_L_shape(canvas: &Canvas) {
             }
             top_stripe_width = Some(stripe_width);
         }
+        y += 1;
     }
+    assert!(y < canvas.size.height);
 
     // Find the bottom part of the L.
     let mut bottom_stripe_width = None;

--- a/src/test.rs
+++ b/src/test.rs
@@ -578,7 +578,11 @@ pub fn rasterize_glyph_with_grayscale_aa() {
             RasterizationOptions::GrayscaleAa,
         )
         .unwrap();
-    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
+    let origin = Point2D::new(
+        -raster_rect.origin.x,
+        raster_rect.size.height + raster_rect.origin.y,
+    )
+    .to_f32();
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
     font.rasterize_glyph(
         &mut canvas,
@@ -610,7 +614,11 @@ pub fn rasterize_glyph_bilevel() {
             RasterizationOptions::Bilevel,
         )
         .unwrap();
-    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
+    let origin = Point2D::new(
+        -raster_rect.origin.x,
+        raster_rect.size.height + raster_rect.origin.y,
+    )
+    .to_f32();
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
     font.rasterize_glyph(
         &mut canvas,
@@ -650,7 +658,11 @@ pub fn rasterize_glyph_with_full_hinting() {
             RasterizationOptions::Bilevel,
         )
         .unwrap();
-    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
+    let origin = Point2D::new(
+        -raster_rect.origin.x,
+        raster_rect.size.height + raster_rect.origin.y,
+    )
+    .to_f32();
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
     font.rasterize_glyph(
         &mut canvas,
@@ -664,7 +676,11 @@ pub fn rasterize_glyph_with_full_hinting() {
     check_L_shape(&canvas);
 
     // Make sure the top and bottom (non-blank) rows have some fully black pixels in them.
-    let top_row = &canvas.pixels[0..canvas.stride];
+    let mut top_row = &canvas.pixels[0..canvas.stride];
+    if top_row.iter().all(|&value| value == 0) {
+        top_row = &canvas.pixels[(1 * canvas.stride)..(2 * canvas.stride)];
+    }
+
     assert!(top_row.iter().any(|&value| value == 0xff));
     for y in (0..(canvas.size.height as usize)).rev() {
         let bottom_row = &canvas.pixels[(y * canvas.stride)..((y + 1) * canvas.stride)];


### PR DESCRIPTION
This change makes the positioning of in the canvas consistent between the
loaders on all platforms. It adopts the convention of having the origin at the
top left with +y going down. Glyphs with their baseline at the specified
offset. This follows the convention of cairo and HTML canvas.

The version is bumped because of this behaviour change.