### PR TITLE
fix README example so that glyph isn't rendered off canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ font.rasterize_glyph(
     &mut canvas,
     glyph_id,
     32.0,
-    &Point2D::zero(),
+    &Point2D::new(0.0, 32.0),
     HintingOptions::None,
     RasterizationOptions::GrayscaleAa,
 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!                          glyph_id,
 //!                          32.0,
 //!                          &FontTransform::identity(),
-//!                          &Point2D::zero(),
+//!                          &Point2D::new(0.0, 32.0),
 //!                          HintingOptions::None,
 //!                          RasterizationOptions::GrayscaleAa)
 //!         .unwrap();


### PR DESCRIPTION
Currently this example leaves the canvas blank.