### PR TITLE
Don't crash with freetype supplies a non-null family name.

### DIFF
--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -341,10 +341,13 @@ impl Font {
     /// Returns the name of the font family.
     pub fn family_name(&self) -> String {
         unsafe {
-            CStr::from_ptr((*self.freetype_face).family_name)
-                .to_str()
-                .unwrap()
-                .to_owned()
+            let ptr = (*self.freetype_face).family_name;
+            // FreeType doesn't guarantee a non-null family name (see issue #5).
+            if ptr.is_null() {
+                String::new()
+            } else {
+                CStr::from_ptr(ptr).to_str().unwrap().to_owned()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5.

I don't know if returning an empty string is the right thing to do when FreeType has a null family name, but at least it doesn't crash. In any case, I've verified with the following C program that FreeType will happily load a font with no family name and report no errors:

```
#include <stdio.h>

#include <ft2build.h>
#include FT_FREETYPE_H

int main()
{
    FT_Library library;
    FT_Face face;

    FT_Init_FreeType(&library);
    FT_Error error = FT_New_Face(library, "/usr/share/fonts/misc/decsess.pcf.gz", 0, &face);
    if (error) {
        printf("Error opening face: %s\n", FT_Error_String(error));
        return 1;
    }
    printf("Success opening face. Family name: %s\n", face->family_name);
    return 0;
}
```